### PR TITLE
feat(signing): add raw cryptographic signing for compact signatures

### DIFF
--- a/signing/raw.go
+++ b/signing/raw.go
@@ -1,0 +1,273 @@
+// Package signing provides raw cryptographic signing functionality
+// for compact signatures suitable for QR codes and other size-constrained scenarios.
+package signing
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"errors"
+	"fmt"
+	"math/big"
+
+	"github.com/jasoet/gopki/keypair"
+	"github.com/jasoet/gopki/keypair/algo"
+)
+
+// Raw signing errors
+var (
+	ErrUnsupportedKeyType = errors.New("unsupported key type for raw signing")
+	ErrInvalidPublicKey   = errors.New("invalid public key")
+	ErrSignatureTooShort  = errors.New("signature too short")
+)
+
+// RawSignOptions configures raw signing operations
+type RawSignOptions struct {
+	// Hash algorithm to use (default: SHA256)
+	HashAlgorithm crypto.Hash
+	// Encode signature to base64 (default: false, returns raw bytes)
+	Base64Encode bool
+}
+
+// DefaultRawSignOptions returns default options for raw signing
+func DefaultRawSignOptions() RawSignOptions {
+	return RawSignOptions{
+		HashAlgorithm: crypto.SHA256,
+		Base64Encode:  false,
+	}
+}
+
+// SignRaw creates a raw cryptographic signature suitable for compact use cases like QR codes.
+// This produces minimal-size signatures without PKCS#7 overhead.
+//
+// Signature sizes:
+//   - ECDSA P-256: 64 bytes (R||S format, 32 bytes each)
+//   - ECDSA P-384: 96 bytes (R||S format, 48 bytes each)
+//   - Ed25519: 64 bytes
+//   - RSA: Variable (typically 256 bytes for RSA-2048)
+//
+// Parameters:
+//   - data: The data to sign
+//   - keyPair: The key pair to use for signing
+//   - opts: Signing options (use DefaultRawSignOptions() for defaults)
+//
+// Returns the raw signature bytes or base64-encoded string (if Base64Encode is true).
+//
+// Example:
+//
+//	keyPair, _ := algo.GenerateECDSAKeyPair(algo.P256)
+//	signature, err := SignRaw([]byte("data"), keyPair, DefaultRawSignOptions())
+//	// Returns 64-byte signature for ECDSA P-256
+func SignRaw[T keypair.KeyPair](data []byte, keyPair T, opts RawSignOptions) ([]byte, error) {
+	if opts.HashAlgorithm == 0 {
+		opts.HashAlgorithm = crypto.SHA256
+	}
+
+	// Hash the data
+	hasher := opts.HashAlgorithm.New()
+	hasher.Write(data)
+	digest := hasher.Sum(nil)
+
+	var signature []byte
+	var err error
+
+	// Sign based on key type
+	switch kp := any(keyPair).(type) {
+	case *algo.ECDSAKeyPair:
+		signature, err = signECDSARaw(kp.PrivateKey, digest)
+	case *algo.Ed25519KeyPair:
+		signature = ed25519.Sign(kp.PrivateKey, data)
+	case *algo.RSAKeyPair:
+		signature, err = rsa.SignPKCS1v15(rand.Reader, kp.PrivateKey, opts.HashAlgorithm, digest)
+	default:
+		return nil, ErrUnsupportedKeyType
+	}
+
+	if err != nil {
+		return nil, fmt.Errorf("failed to sign: %w", err)
+	}
+
+	if opts.Base64Encode {
+		encoded := base64.StdEncoding.EncodeToString(signature)
+		return []byte(encoded), nil
+	}
+
+	return signature, nil
+}
+
+// SignRawString is a convenience wrapper that returns base64-encoded signature as string.
+//
+// Example:
+//
+//	keyPair, _ := algo.GenerateECDSAKeyPair(algo.P256)
+//	signature, err := SignRawString([]byte("data"), keyPair, DefaultRawSignOptions())
+//	// Returns base64-encoded signature string
+func SignRawString[T keypair.KeyPair](data []byte, keyPair T, opts RawSignOptions) (string, error) {
+	opts.Base64Encode = true
+	sig, err := SignRaw(data, keyPair, opts)
+	if err != nil {
+		return "", err
+	}
+	return string(sig), nil
+}
+
+// VerifyRaw verifies a raw cryptographic signature.
+//
+// Parameters:
+//   - data: The original data that was signed
+//   - signature: The signature bytes (or base64-encoded string)
+//   - publicKey: The public key to verify with
+//   - opts: Verification options
+//
+// Returns true if the signature is valid, false otherwise.
+//
+// Example:
+//
+//	valid, err := VerifyRaw(data, signature, publicKey, DefaultRawSignOptions())
+func VerifyRaw(data []byte, signature []byte, publicKey crypto.PublicKey, opts RawSignOptions) (bool, error) {
+	if opts.HashAlgorithm == 0 {
+		opts.HashAlgorithm = crypto.SHA256
+	}
+
+	// Check if signature is base64-encoded and decode if needed
+	if opts.Base64Encode {
+		decoded, err := base64.StdEncoding.DecodeString(string(signature))
+		if err != nil {
+			return false, fmt.Errorf("failed to decode base64 signature: %w", err)
+		}
+		signature = decoded
+	}
+
+	// Hash the data
+	hasher := opts.HashAlgorithm.New()
+	hasher.Write(data)
+	digest := hasher.Sum(nil)
+
+	// Verify based on key type
+	switch pub := publicKey.(type) {
+	case *ecdsa.PublicKey:
+		return verifyECDSARaw(pub, digest, signature)
+	case ed25519.PublicKey:
+		return ed25519.Verify(pub, data, signature), nil
+	case *rsa.PublicKey:
+		err := rsa.VerifyPKCS1v15(pub, opts.HashAlgorithm, digest, signature)
+		return err == nil, err
+	default:
+		return false, ErrUnsupportedKeyType
+	}
+}
+
+// VerifyRawString is a convenience wrapper for verifying base64-encoded signatures.
+//
+// Example:
+//
+//	valid, err := VerifyRawString(data, signatureBase64, publicKey, DefaultRawSignOptions())
+func VerifyRawString(data []byte, signatureBase64 string, publicKey crypto.PublicKey, opts RawSignOptions) (bool, error) {
+	signature, err := base64.StdEncoding.DecodeString(signatureBase64)
+	if err != nil {
+		return false, fmt.Errorf("failed to decode signature: %w", err)
+	}
+
+	opts.Base64Encode = false // Already decoded
+	return VerifyRaw(data, signature, publicKey, opts)
+}
+
+// VerifyRawWithPEM verifies a signature using a PEM-encoded public key.
+//
+// Example:
+//
+//	publicKeyPEM := []byte("-----BEGIN PUBLIC KEY-----\n...")
+//	valid, err := VerifyRawWithPEM(data, signature, publicKeyPEM, DefaultRawSignOptions())
+func VerifyRawWithPEM(data []byte, signature []byte, publicKeyPEM []byte, opts RawSignOptions) (bool, error) {
+	publicKey, err := parsePublicKeyFromPEM(publicKeyPEM)
+	if err != nil {
+		return false, err
+	}
+
+	return VerifyRaw(data, signature, publicKey, opts)
+}
+
+// signECDSARaw signs data with ECDSA and returns signature in R||S format
+func signECDSARaw(privateKey *ecdsa.PrivateKey, digest []byte) ([]byte, error) {
+	r, s, err := ecdsa.Sign(rand.Reader, privateKey, digest)
+	if err != nil {
+		return nil, err
+	}
+
+	// Determine signature size based on curve
+	curveBytes := (privateKey.Curve.Params().BitSize + 7) / 8
+
+	// Encode signature (R||S format)
+	signature := make([]byte, curveBytes*2)
+	rBytes := r.Bytes()
+	sBytes := s.Bytes()
+
+	// Pad R and S to curve size
+	copy(signature[curveBytes-len(rBytes):curveBytes], rBytes)
+	copy(signature[len(signature)-len(sBytes):], sBytes)
+
+	return signature, nil
+}
+
+// verifyECDSARaw verifies an ECDSA signature in R||S format
+func verifyECDSARaw(publicKey *ecdsa.PublicKey, digest []byte, signature []byte) (bool, error) {
+	// Determine expected signature size
+	curveBytes := (publicKey.Curve.Params().BitSize + 7) / 8
+	expectedSize := curveBytes * 2
+
+	if len(signature) != expectedSize {
+		return false, fmt.Errorf("invalid signature length: expected %d bytes, got %d", expectedSize, len(signature))
+	}
+
+	// Split signature into R and S
+	r := new(big.Int).SetBytes(signature[:curveBytes])
+	s := new(big.Int).SetBytes(signature[curveBytes:])
+
+	// Verify signature
+	valid := ecdsa.Verify(publicKey, digest, r, s)
+	return valid, nil
+}
+
+// parsePublicKeyFromPEM parses a PEM-encoded public key
+func parsePublicKeyFromPEM(publicKeyPEM []byte) (crypto.PublicKey, error) {
+	block, _ := pem.Decode(publicKeyPEM)
+	if block == nil {
+		return nil, ErrInvalidPublicKey
+	}
+
+	publicKey, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse public key: %w", err)
+	}
+
+	return publicKey, nil
+}
+
+// GetRawSignatureSize returns the expected signature size for a given key type.
+//
+// Returns:
+//   - ECDSA P-256: 64 bytes
+//   - ECDSA P-384: 96 bytes
+//   - ECDSA P-521: 132 bytes
+//   - Ed25519: 64 bytes
+//   - RSA-2048: 256 bytes
+//   - RSA-3072: 384 bytes
+//   - RSA-4096: 512 bytes
+func GetRawSignatureSize(publicKey crypto.PublicKey) (int, error) {
+	switch pub := publicKey.(type) {
+	case *ecdsa.PublicKey:
+		curveBytes := (pub.Curve.Params().BitSize + 7) / 8
+		return curveBytes * 2, nil
+	case ed25519.PublicKey:
+		return ed25519.SignatureSize, nil
+	case *rsa.PublicKey:
+		return pub.Size(), nil
+	default:
+		return 0, ErrUnsupportedKeyType
+	}
+}

--- a/signing/raw_test.go
+++ b/signing/raw_test.go
@@ -1,0 +1,414 @@
+package signing
+
+import (
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/ed25519"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"testing"
+
+	"github.com/jasoet/gopki/keypair/algo"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSignRaw_ECDSA_P256(t *testing.T) {
+	// Generate ECDSA P-256 key pair
+	keyPair, err := algo.GenerateECDSAKeyPair(algo.P256)
+	require.NoError(t, err)
+
+	data := []byte("test data for signing")
+	opts := DefaultRawSignOptions()
+
+	// Test signing
+	signature, err := SignRaw(data, keyPair, opts)
+	require.NoError(t, err)
+	assert.Equal(t, 64, len(signature), "ECDSA P-256 signature should be 64 bytes")
+
+	// Test verification
+	valid, err := VerifyRaw(data, signature, keyPair.PublicKey, opts)
+	require.NoError(t, err)
+	assert.True(t, valid, "Signature should be valid")
+
+	// Test with tampered data
+	tamperedData := []byte("tampered data")
+	valid, err = VerifyRaw(tamperedData, signature, keyPair.PublicKey, opts)
+	require.NoError(t, err)
+	assert.False(t, valid, "Signature should be invalid for tampered data")
+}
+
+func TestSignRaw_ECDSA_P384(t *testing.T) {
+	// Generate ECDSA P-384 key pair
+	keyPair, err := algo.GenerateECDSAKeyPair(algo.P384)
+	require.NoError(t, err)
+
+	data := []byte("test data for P-384")
+	opts := DefaultRawSignOptions()
+	opts.HashAlgorithm = crypto.SHA384
+
+	// Test signing
+	signature, err := SignRaw(data, keyPair, opts)
+	require.NoError(t, err)
+	assert.Equal(t, 96, len(signature), "ECDSA P-384 signature should be 96 bytes")
+
+	// Test verification
+	valid, err := VerifyRaw(data, signature, keyPair.PublicKey, opts)
+	require.NoError(t, err)
+	assert.True(t, valid, "Signature should be valid")
+}
+
+func TestSignRaw_Ed25519(t *testing.T) {
+	// Generate Ed25519 key pair
+	keyPair, err := algo.GenerateEd25519KeyPair()
+	require.NoError(t, err)
+
+	data := []byte("test data for Ed25519")
+	opts := DefaultRawSignOptions()
+
+	// Test signing
+	signature, err := SignRaw(data, keyPair, opts)
+	require.NoError(t, err)
+	assert.Equal(t, ed25519.SignatureSize, len(signature), "Ed25519 signature should be 64 bytes")
+
+	// Test verification
+	valid, err := VerifyRaw(data, signature, keyPair.PublicKey, opts)
+	require.NoError(t, err)
+	assert.True(t, valid, "Signature should be valid")
+}
+
+func TestSignRaw_RSA(t *testing.T) {
+	// Generate RSA key pair
+	keyPair, err := algo.GenerateRSAKeyPair(algo.KeySize2048)
+	require.NoError(t, err)
+
+	data := []byte("test data for RSA")
+	opts := DefaultRawSignOptions()
+
+	// Test signing
+	signature, err := SignRaw(data, keyPair, opts)
+	require.NoError(t, err)
+	assert.Equal(t, 256, len(signature), "RSA-2048 signature should be 256 bytes")
+
+	// Test verification
+	valid, err := VerifyRaw(data, signature, keyPair.PublicKey, opts)
+	require.NoError(t, err)
+	assert.True(t, valid, "Signature should be valid")
+}
+
+func TestSignRawString_Base64(t *testing.T) {
+	// Generate key pair
+	keyPair, err := algo.GenerateECDSAKeyPair(algo.P256)
+	require.NoError(t, err)
+
+	data := []byte("test data for base64 encoding")
+	opts := DefaultRawSignOptions()
+
+	// Test string signing (returns base64)
+	signatureBase64, err := SignRawString(data, keyPair, opts)
+	require.NoError(t, err)
+	assert.NotEmpty(t, signatureBase64)
+
+	// Verify it's valid base64
+	decoded, err := base64.StdEncoding.DecodeString(signatureBase64)
+	require.NoError(t, err)
+	assert.Equal(t, 64, len(decoded))
+
+	// Test verification with string
+	valid, err := VerifyRawString(data, signatureBase64, keyPair.PublicKey, opts)
+	require.NoError(t, err)
+	assert.True(t, valid, "Signature should be valid")
+}
+
+func TestSignRaw_WithBase64Option(t *testing.T) {
+	keyPair, err := algo.GenerateECDSAKeyPair(algo.P256)
+	require.NoError(t, err)
+
+	data := []byte("test data")
+	opts := DefaultRawSignOptions()
+	opts.Base64Encode = true
+
+	// Sign with base64 encoding
+	signature, err := SignRaw(data, keyPair, opts)
+	require.NoError(t, err)
+
+	// Should be base64 string
+	signatureStr := string(signature)
+	decoded, err := base64.StdEncoding.DecodeString(signatureStr)
+	require.NoError(t, err)
+	assert.Equal(t, 64, len(decoded))
+
+	// Verify with base64
+	valid, err := VerifyRaw(data, signature, keyPair.PublicKey, opts)
+	require.NoError(t, err)
+	assert.True(t, valid)
+}
+
+func TestVerifyRaw_InvalidSignatureLength(t *testing.T) {
+	keyPair, err := algo.GenerateECDSAKeyPair(algo.P256)
+	require.NoError(t, err)
+
+	data := []byte("test data")
+	opts := DefaultRawSignOptions()
+
+	// Test with invalid signature length
+	invalidSignature := make([]byte, 32) // Should be 64 for P-256
+	valid, err := VerifyRaw(data, invalidSignature, keyPair.PublicKey, opts)
+	assert.Error(t, err)
+	assert.False(t, valid)
+}
+
+func TestVerifyRawWithPEM(t *testing.T) {
+	// Generate key pair
+	keyPair, err := algo.GenerateECDSAKeyPair(algo.P256)
+	require.NoError(t, err)
+
+	// Get PEM-encoded public key
+	publicKeyPEM, err := keyPair.PublicKeyToPEM()
+	require.NoError(t, err)
+
+	data := []byte("test data for PEM verification")
+	opts := DefaultRawSignOptions()
+
+	// Sign
+	signature, err := SignRaw(data, keyPair, opts)
+	require.NoError(t, err)
+
+	// Verify with PEM
+	valid, err := VerifyRawWithPEM(data, signature, publicKeyPEM, opts)
+	require.NoError(t, err)
+	assert.True(t, valid)
+}
+
+func TestGetRawSignatureSize(t *testing.T) {
+	tests := []struct {
+		name         string
+		generateKey  func() (crypto.PublicKey, error)
+		expectedSize int
+	}{
+		{
+			name: "ECDSA P-256",
+			generateKey: func() (crypto.PublicKey, error) {
+				kp, err := algo.GenerateECDSAKeyPair(algo.P256)
+				return kp.PublicKey, err
+			},
+			expectedSize: 64,
+		},
+		{
+			name: "ECDSA P-384",
+			generateKey: func() (crypto.PublicKey, error) {
+				kp, err := algo.GenerateECDSAKeyPair(algo.P384)
+				return kp.PublicKey, err
+			},
+			expectedSize: 96,
+		},
+		{
+			name: "Ed25519",
+			generateKey: func() (crypto.PublicKey, error) {
+				kp, err := algo.GenerateEd25519KeyPair()
+				return kp.PublicKey, err
+			},
+			expectedSize: 64,
+		},
+		{
+			name: "RSA-2048",
+			generateKey: func() (crypto.PublicKey, error) {
+				kp, err := algo.GenerateRSAKeyPair(algo.KeySize2048)
+				return kp.PublicKey, err
+			},
+			expectedSize: 256,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			publicKey, err := tt.generateKey()
+			require.NoError(t, err)
+
+			size, err := GetRawSignatureSize(publicKey)
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedSize, size)
+		})
+	}
+}
+
+
+func TestSignRaw_DifferentHashAlgorithms(t *testing.T) {
+	keyPair, err := algo.GenerateECDSAKeyPair(algo.P256)
+	require.NoError(t, err)
+
+	data := []byte("test data")
+
+	tests := []struct {
+		name     string
+		hashAlgo crypto.Hash
+	}{
+		{"SHA256", crypto.SHA256},
+		{"SHA384", crypto.SHA384},
+		{"SHA512", crypto.SHA512},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			opts := DefaultRawSignOptions()
+			opts.HashAlgorithm = tt.hashAlgo
+
+			signature, err := SignRaw(data, keyPair, opts)
+			require.NoError(t, err)
+
+			valid, err := VerifyRaw(data, signature, keyPair.PublicKey, opts)
+			require.NoError(t, err)
+			assert.True(t, valid)
+		})
+	}
+}
+
+func TestSignRaw_MultipleRuns(t *testing.T) {
+	// Test that signing the same data produces different signatures due to randomness
+	keyPair, err := algo.GenerateECDSAKeyPair(algo.P256)
+	require.NoError(t, err)
+
+	data := []byte("test data")
+	opts := DefaultRawSignOptions()
+
+	// Sign multiple times
+	signatures := make([][]byte, 10)
+	for i := 0; i < 10; i++ {
+		sig, err := SignRaw(data, keyPair, opts)
+		require.NoError(t, err)
+		signatures[i] = sig
+
+		// Verify each signature
+		valid, err := VerifyRaw(data, sig, keyPair.PublicKey, opts)
+		require.NoError(t, err)
+		assert.True(t, valid)
+	}
+
+	// ECDSA signatures should be different due to random k value
+	// (This is a property of ECDSA, not a bug)
+	allSame := true
+	for i := 1; i < len(signatures); i++ {
+		if !assert.ObjectsAreEqual(signatures[0], signatures[i]) {
+			allSame = false
+			break
+		}
+	}
+	assert.False(t, allSame, "ECDSA signatures should vary due to randomness")
+}
+
+func TestVerifyRaw_WrongKey(t *testing.T) {
+	// Generate two different key pairs
+	keyPair1, err := algo.GenerateECDSAKeyPair(algo.P256)
+	require.NoError(t, err)
+
+	keyPair2, err := algo.GenerateECDSAKeyPair(algo.P256)
+	require.NoError(t, err)
+
+	data := []byte("test data")
+	opts := DefaultRawSignOptions()
+
+	// Sign with key 1
+	signature, err := SignRaw(data, keyPair1, opts)
+	require.NoError(t, err)
+
+	// Try to verify with key 2 (should fail)
+	valid, err := VerifyRaw(data, signature, keyPair2.PublicKey, opts)
+	require.NoError(t, err)
+	assert.False(t, valid, "Signature should not verify with wrong key")
+}
+
+// Benchmark tests
+func BenchmarkSignRaw_ECDSA_P256(b *testing.B) {
+	keyPair, _ := algo.GenerateECDSAKeyPair(algo.P256)
+	data := []byte("benchmark data")
+	opts := DefaultRawSignOptions()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = SignRaw(data, keyPair, opts)
+	}
+}
+
+func BenchmarkVerifyRaw_ECDSA_P256(b *testing.B) {
+	keyPair, _ := algo.GenerateECDSAKeyPair(algo.P256)
+	data := []byte("benchmark data")
+	opts := DefaultRawSignOptions()
+	signature, _ := SignRaw(data, keyPair, opts)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = VerifyRaw(data, signature, keyPair.PublicKey, opts)
+	}
+}
+
+func BenchmarkSignRaw_Ed25519(b *testing.B) {
+	keyPair, _ := algo.GenerateEd25519KeyPair()
+	data := []byte("benchmark data")
+	opts := DefaultRawSignOptions()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = SignRaw(data, keyPair, opts)
+	}
+}
+
+func BenchmarkSignRaw_RSA2048(b *testing.B) {
+	keyPair, _ := algo.GenerateRSAKeyPair(algo.KeySize2048)
+	data := []byte("benchmark data")
+	opts := DefaultRawSignOptions()
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = SignRaw(data, keyPair, opts)
+	}
+}
+
+// Test internal functions
+func Test_signECDSARaw(t *testing.T) {
+	// Generate a raw ECDSA private key
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	data := []byte("test data")
+	hash := sha256.Sum256(data)
+	digest := hash[:]
+
+	signature, err := signECDSARaw(privateKey, digest)
+	require.NoError(t, err)
+	assert.Equal(t, 64, len(signature))
+}
+
+func Test_verifyECDSARaw(t *testing.T) {
+	// Generate key pair
+	privateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	data := []byte("test data")
+	hash := sha256.Sum256(data)
+	digest := hash[:]
+
+	// Sign
+	signature, err := signECDSARaw(privateKey, digest)
+	require.NoError(t, err)
+
+	// Verify
+	valid, err := verifyECDSARaw(&privateKey.PublicKey, digest, signature)
+	require.NoError(t, err)
+	assert.True(t, valid)
+
+	// Verify with tampered data
+	tamperedData := []byte("tampered data")
+	tamperedHash := sha256.Sum256(tamperedData)
+	tamperedDigest := tamperedHash[:]
+	valid, err = verifyECDSARaw(&privateKey.PublicKey, tamperedDigest, signature)
+	require.NoError(t, err)
+	assert.False(t, valid)
+}
+
+func TestDefaultRawSignOptions(t *testing.T) {
+	opts := DefaultRawSignOptions()
+	assert.Equal(t, crypto.SHA256, opts.HashAlgorithm)
+	assert.False(t, opts.Base64Encode)
+}


### PR DESCRIPTION
## Summary
- Add raw signing functionality for compact signatures suitable for QR codes and size-constrained scenarios
- Implement `SignRaw`/`SignRawString` for creating minimal-size signatures without PKCS#7 overhead
- Implement `VerifyRaw`/`VerifyRawString`/`VerifyRawWithPEM` for signature verification
- Support multiple algorithms with predictable signature sizes

## Features
- **ECDSA Support**: P-256 (64 bytes), P-384 (96 bytes), P-521 (132 bytes)
- **Ed25519 Support**: 64-byte signatures
- **RSA Support**: Variable size (256 bytes for RSA-2048)
- **Configurable Options**: Hash algorithms (SHA256/384/512), base64 encoding
- **Helper Functions**: `GetRawSignatureSize` for determining expected signature sizes

## Implementation Details
- Uses R||S format for ECDSA signatures (fixed-width, no ASN.1 overhead)
- Ed25519 signatures use native format
- RSA signatures use PKCS1v15 format
- All signatures are hashed with configurable algorithm (default: SHA256)

## Test Coverage
- 16+ comprehensive test cases covering:
  - All supported algorithms (ECDSA P-256/P-384, Ed25519, RSA-2048)
  - Base64 encoding/decoding
  - Different hash algorithms
  - Invalid signatures and tampered data
  - Wrong key verification
  - PEM public key verification
  - Multiple signing runs (randomness validation)
  - Signature size validation
  - Internal function tests

## Test Results
```
=== RUN   TestSignRaw_ECDSA_P256
--- PASS: TestSignRaw_ECDSA_P256 (0.00s)
=== RUN   TestSignRaw_ECDSA_P384
--- PASS: TestSignRaw_ECDSA_P384 (0.00s)
=== RUN   TestSignRaw_Ed25519
--- PASS: TestSignRaw_Ed25519 (0.00s)
=== RUN   TestSignRaw_RSA
--- PASS: TestSignRaw_RSA (0.02s)
... (all 40 tests passed)
PASS
ok      github.com/jasoet/gopki/signing 1.857s
```

## Usage Example
```go
// Generate key pair
keyPair, _ := algo.GenerateECDSAKeyPair(algo.P256)

// Sign data
signature, _ := signing.SignRaw([]byte("data"), keyPair, signing.DefaultRawSignOptions())
// Returns 64-byte signature for ECDSA P-256

// Verify signature
valid, _ := signing.VerifyRaw(data, signature, keyPair.PublicKey, signing.DefaultRawSignOptions())
```